### PR TITLE
Adds function to remove all empty attributes before html is rendered

### DIFF
--- a/Sources/Transfer/HTMLElement+Attribute.swift
+++ b/Sources/Transfer/HTMLElement+Attribute.swift
@@ -88,6 +88,13 @@ public extension HTMLElement.Attribute {
     }
 }
 
+public extension Array where Element == HTMLElement.Attribute {
+    func ignoringEmpty() -> [HTMLElement.Attribute] {
+        filter { $0.getValue() != "\"\"" }
+    }
+    
+}
+
 fileprivate extension HTMLElement.Attribute {
     func getValue() -> String {
         switch self {

--- a/Sources/Transfer/Transferable.swift
+++ b/Sources/Transfer/Transferable.swift
@@ -21,9 +21,7 @@ extension Transferable {
     /// - Parameter attributes: HTMLElement.Attibute (.class, .style, etc.,)
     /// - Returns: A fully built String of HTMLElement Attributes i.e. " class="someClass" src="someSource""
     func elementAttributes(_ attributes: [HTMLElement.Attribute]) -> String {
-        attributes
-            .ignoringEmpty()
-            .compactMap { $0.toHTMLAttribute() }.joined()
+        attributes.ignoringEmpty().compactMap { $0.toHTMLAttribute() }.joined()
     }
 }
 

--- a/Sources/Transfer/Transferable.swift
+++ b/Sources/Transfer/Transferable.swift
@@ -21,7 +21,9 @@ extension Transferable {
     /// - Parameter attributes: HTMLElement.Attibute (.class, .style, etc.,)
     /// - Returns: A fully built String of HTMLElement Attributes i.e. " class="someClass" src="someSource""
     func elementAttributes(_ attributes: [HTMLElement.Attribute]) -> String {
-        attributes.compactMap { $0.toHTMLAttribute() }.joined()
+        attributes
+            .ignoringEmpty()
+            .compactMap { $0.toHTMLAttribute() }.joined()
     }
 }
 

--- a/Tests/TransferTests/HTMLElement+AttributeTests.swift
+++ b/Tests/TransferTests/HTMLElement+AttributeTests.swift
@@ -10,4 +10,11 @@ final class AttributesTests: XCTestCase {
         XCTAssertEqual(HTMLElement.Attribute.custom(key: "data-2.0", value: "nein!").toHTMLAttribute(), " data-2.0=\"nein!\"")
     }
 
+    func testIgnoringEmpty() {
+        XCTAssertEqual(
+            [HTMLElement.Attribute.class(value: "")].ignoringEmpty().count,
+            0
+        )
+    }
+    
 }

--- a/Tests/TransferTests/HTMLElement+AttributeTests.swift
+++ b/Tests/TransferTests/HTMLElement+AttributeTests.swift
@@ -15,6 +15,12 @@ final class AttributesTests: XCTestCase {
             [HTMLElement.Attribute.class(value: "")].ignoringEmpty().count,
             0
         )
+        
+        XCTAssertEqual(
+            [HTMLElement.Attribute.class(value: "a")].ignoringEmpty().count,
+            1
+        )
+        
     }
     
 }

--- a/Tests/TransferTests/PageTests.swift
+++ b/Tests/TransferTests/PageTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class PageTests: XCTestCase {
     
-    let result = "<html lang=\"en\"><head><title>Title</title><link rel=\"stylesheet\" href=\"styles/someThing.css\"></link><link rel=\"icon\" href=\"favicon.ico\"></link></head><body><h1 class=\"\">This is your title</h1><div class=\"someClass\"><p class=\"bold\">This is a test</p></div></body></html>"
+    let result = "<html lang=\"en\"><head><title>Title</title><link rel=\"stylesheet\" href=\"styles/someThing.css\"></link><link rel=\"icon\" href=\"favicon.ico\"></link></head><body><h1>This is your title</h1><div class=\"someClass\"><p class=\"bold\">This is a test</p></div></body></html>"
     
     func testPageRendersHTML() {
         let content: [TransferElement] = [.styleSheet("styles/someThing.css"), .favicon()]

--- a/Tests/TransferTests/TransferElement+HelpersTests.swift
+++ b/Tests/TransferTests/TransferElement+HelpersTests.swift
@@ -7,7 +7,7 @@ final class TransferElementHelperTests: XCTestCase {
     
     lazy var artical = TransferElement.article(a)
     lazy var renderedA = """
-<a href="a" target="_blank" class=\"\">b</a>
+<a href="a" target="_blank">b</a>
 """
     
     func testAnchorPrePopulatesWithSetAttributes() {
@@ -46,7 +46,7 @@ final class TransferElementHelperTests: XCTestCase {
     
     func testImagePrepopulatesAttributes() {
         assert(.img("img/1.png"), matches: """
-<img src="img/1.png" alt="" class=""></img>
+<img src="img/1.png"></img>
 """)
     }
     
@@ -88,7 +88,7 @@ final class TransferElementHelperTests: XCTestCase {
     
     func rendered(_ element: String, _ content: String = "") -> String {
         """
-<\(element) class=\"\">\(content)</\(element)>
+<\(element)>\(content)</\(element)>
 """
     }
 }


### PR DESCRIPTION
# Remove erroneous attributes

## Summary

Initially, when I created the helper methods, empty attributes were being rendered in the HTML. They still worked, but it's not ideal. This filters those out before the render.


#### Characteristics

- [x] Feature completed
- [ ] Dark code


#### Tests

- [x] Tests are included in this PR
- [ ] Tests were not included in this PR because ____


#### Build/Tests

- [x] Builds and runs
- [x] Unit tests pass
